### PR TITLE
Links are also underlined in lists, not only paragraphs

### DIFF
--- a/css/basic.css
+++ b/css/basic.css
@@ -7,7 +7,8 @@ p {
   line-height: 1.5;
   margin: 30px 0;
 }
-p a {
+p a,
+li a {
   text-decoration: underline;
 }
 h1,


### PR DESCRIPTION
It looks like standard links are only underlined when they are within `<p>` tags.

This PR applies this style also to `<li>` tags, so links look consistent and are easy to spot (otherwise they don't stand out from the black font color).
