### PR TITLE
RSS link was linking to an invalid URL when not on the homepage

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -29,7 +29,7 @@
                             </a>
                         </li>
                         <li>
-                            <a href="feeds/rss">
+			    <a href="<?php echo base_url(); ?>feeds/rss">
                                 <span class="fa-stack fa-lg">
                                     <i class="fa fa-circle fa-stack-2x"></i>
                                     <i class="fa fa-rss fa-stack-1x fa-inverse"></i>


### PR DESCRIPTION
The RSS link at the bottom of each page doesn't work unless the user clicks it from the homepage.

This is due to the `href` attribute having a relative URL. I have changed this to use Anchor's `base_url()` instead.
